### PR TITLE
Add proxy and file upload decorators

### DIFF
--- a/packages/http/adapters/default.adapter.ts
+++ b/packages/http/adapters/default.adapter.ts
@@ -557,6 +557,14 @@ export class DefaultAdapter extends AbstractHttpAdapter<
                 case 'hosts':
                     args[param.index] = req.hosts;
                     break;
+                case 'file':
+                    args[param.index] = paramName
+                        ? req.files?.[paramName]
+                        : req.files;
+                    break;
+                case 'files':
+                    args[param.index] = req.files;
+                    break;
                 default:
                     args[param.index] = undefined;
                     break;

--- a/packages/http/decorators/controller.decorator.ts
+++ b/packages/http/decorators/controller.decorator.ts
@@ -243,3 +243,11 @@ export function Ip(): ParameterDecorator {
 export function HostParam(): ParameterDecorator {
     return createParamDecorator(`hosts`);
 }
+
+export function UploadedFile(fieldName?: string): ParameterDecorator {
+    return createParamDecorator(fieldName ? `file:${fieldName}` : 'file');
+}
+
+export function UploadedFiles(): ParameterDecorator {
+    return createParamDecorator('files');
+}

--- a/packages/http/decorators/index.ts
+++ b/packages/http/decorators/index.ts
@@ -8,3 +8,4 @@ export * from './last-modified.decorator';
 export * from './raw.decorator';
 export * from './redirect.decorator';
 export * from './route-middleware.util';
+export * from './proxy.decorator';

--- a/packages/http/decorators/proxy.decorator.ts
+++ b/packages/http/decorators/proxy.decorator.ts
@@ -1,0 +1,8 @@
+import { proxy, ProxyOptions } from '@cmmv/proxy';
+import { createRouteMiddleware } from './route-middleware.util';
+
+export function Proxy(options: ProxyOptions): MethodDecorator {
+    return (_target, _propertyKey: string | symbol, descriptor: any) => {
+        createRouteMiddleware(proxy(options), descriptor);
+    };
+}

--- a/packages/http/tests/controller.spec.ts
+++ b/packages/http/tests/controller.spec.ts
@@ -13,9 +13,13 @@ import {
     Header,
     Request,
     Response,
-} from '../decorators/controller.decorator';
+    Proxy,
+    UploadedFile,
+    UploadedFiles,
+} from '../decorators';
 
 import { ControllerRegistry } from '../registries/controller.registry';
+import { ProxyMiddleware } from '@cmmv/proxy';
 
 describe('Controller Decorators', () => {
     beforeEach(() => {
@@ -190,5 +194,43 @@ describe('Controller Decorators', () => {
         );
         expect(params.length).toBe(1);
         expect(params[0].paramType).toBe('response');
+    });
+
+    it('should register proxy middleware for a route', () => {
+        @Controller()
+        class TestController {
+            @Get('/proxy')
+            @Proxy({ target: 'http://example.com' })
+            test() {}
+        }
+
+        const routes = ControllerRegistry.getRoutes(TestController);
+        expect(routes[0].middlewares?.[0]).toBeInstanceOf(Function);
+    });
+
+    it('should register UploadedFile parameter', () => {
+        @Controller()
+        class TestController {
+            test(@UploadedFile('avatar') file: any) {}
+        }
+
+        const params = ControllerRegistry.getParams(
+            TestController.prototype,
+            'test',
+        );
+        expect(params[0].paramType).toBe('file:avatar');
+    });
+
+    it('should register UploadedFiles parameter', () => {
+        @Controller()
+        class TestController {
+            test(@UploadedFiles() files: any) {}
+        }
+
+        const params = ControllerRegistry.getParams(
+            TestController.prototype,
+            'test',
+        );
+        expect(params[0].paramType).toBe('files');
     });
 });


### PR DESCRIPTION
## Summary
- add Proxy decorator
- support file uploads via UploadedFile and UploadedFiles decorators
- handle file parameters in default adapter
- export Proxy decorator
- test new decorators

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684e13702970833395cfd89ee6f8bfd4